### PR TITLE
Fix cache key generation

### DIFF
--- a/src/services/DataService.ts
+++ b/src/services/DataService.ts
@@ -24,8 +24,23 @@ export class DataService {
     return DataService.instance;
   }
 
-  private getCacheKey(table: string, filters: Record<string, any> = {}): string {
-    return `${table}_${JSON.stringify(filters)}`;
+  private getCacheKey(table: string, params: Record<string, any> = {}): string {
+    const stable = (value: any): any => {
+      if (Array.isArray(value)) {
+        return value.map((v) => stable(v));
+      }
+      if (value && typeof value === 'object') {
+        return Object.keys(value)
+          .sort()
+          .reduce((acc: Record<string, any>, key) => {
+            acc[key] = stable(value[key]);
+            return acc;
+          }, {});
+      }
+      return value;
+    };
+
+    return `${table}_${JSON.stringify(stable(params))}`;
   }
 
   private getFromCache<T>(key: string): T | null {


### PR DESCRIPTION
## Summary
- ensure DataService cache key generation is stable by sorting query parameters

## Testing
- `npx tsc -p tsconfig.json`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68619e841fc08333beff375b2188ffa2