### PR TITLE
Fix sidebar links and remove duplicate layout section

### DIFF
--- a/src/components/dashboard/EnhancedDashboard.tsx
+++ b/src/components/dashboard/EnhancedDashboard.tsx
@@ -47,10 +47,10 @@ const quickAccessCards = [
     iconColor: "text-purple-600"
   },
   {
-    title: "Fluxo de Caixa", 
+    title: "Fluxo de Caixa",
     description: "Gestão financeira",
     icon: DollarSign,
-    href: "/fluxo-de-caixa",
+    href: "/fluxo-caixa",
     gradient: "from-blue-500 to-blue-600",
     iconBg: "bg-blue-100", 
     iconColor: "text-blue-600"

--- a/src/components/dashboard/QuickAccessGrid.tsx
+++ b/src/components/dashboard/QuickAccessGrid.tsx
@@ -20,10 +20,10 @@ const quickAccessCards = [
     iconColor: "text-purple-600"
   },
   {
-    title: "Fluxo de Caixa", 
+    title: "Fluxo de Caixa",
     description: "Gestão financeira",
     icon: DollarSign,
-    href: "/fluxo-de-caixa",
+    href: "/fluxo-caixa",
     gradient: "from-green-500 to-green-600",
     iconBg: "bg-green-100", 
     iconColor: "text-green-600"

--- a/src/components/dashboard/StreamlinedDashboard.tsx
+++ b/src/components/dashboard/StreamlinedDashboard.tsx
@@ -34,10 +34,10 @@ const quickAccessCards = [
     iconColor: "text-purple-600"
   },
   {
-    title: "Fluxo de Caixa", 
+    title: "Fluxo de Caixa",
     description: "Gestão financeira",
     icon: DollarSign,
-    href: "/fluxo-de-caixa",
+    href: "/fluxo-caixa",
     gradient: "from-green-500 to-green-600",
     iconBg: "bg-green-100", 
     iconColor: "text-green-600"

--- a/src/components/restaurant/ModernLayout.tsx
+++ b/src/components/restaurant/ModernLayout.tsx
@@ -3,8 +3,7 @@ import { useState } from "react";
 import { ModernSidebar } from "./ModernSidebar";
 import { SystemHealthIndicator } from "@/components/system/SystemHealthIndicator";
 import { Button } from "@/components/ui/button";
-import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
-import { Menu, Activity } from "lucide-react";
+import { Activity } from "lucide-react";
 
 interface ModernLayoutProps {
   children: React.ReactNode;
@@ -15,30 +14,6 @@ export function ModernLayout({ children }: ModernLayoutProps) {
   
   return (
     <div className="min-h-screen bg-background">
-      {/* Mobile Header - Hidden as ModernSidebar handles mobile menu */}
-      <div className="lg:hidden flex items-center justify-between p-4 border-b" style={{ display: 'none' }}>
-        <Sheet>
-          <SheetTrigger asChild>
-            <Button variant="ghost" size="icon">
-              <Menu className="h-6 w-6" />
-            </Button>
-          </SheetTrigger>
-          <SheetContent side="left" className="p-0">
-            <ModernSidebar />
-          </SheetContent>
-        </Sheet>
-        
-        <div className="flex items-center gap-2">
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={() => setShowHealthIndicator(!showHealthIndicator)}
-          >
-            <Activity className="h-5 w-5" />
-          </Button>
-        </div>
-      </div>
-
       <div className="lg:grid lg:grid-cols-[280px_1fr]">
         {/* Desktop Sidebar */}
         <div className="hidden lg:block border-r bg-muted/10">

--- a/src/hooks/useInterfaceAudit.ts
+++ b/src/hooks/useInterfaceAudit.ts
@@ -43,7 +43,7 @@ export function useInterfaceAudit(config?: AuditConfig) {
       '/dre',
       '/cmv',
       '/dre-cmv',
-      '/fluxo-de-caixa',
+      '/fluxo-caixa',
       '/simulador',
       '/metas',
       '/estoque',

--- a/src/utils/duplicateAuditor.ts
+++ b/src/utils/duplicateAuditor.ts
@@ -174,7 +174,7 @@ export class DuplicateAuditor {
   private auditRouteDuplicates(): string[] {
     // Verificar rotas duplicadas no sistema
     const routes = [
-      '/dashboard', '/projecoes', '/dre', '/cmv', '/fluxo-de-caixa',
+      '/dashboard', '/projecoes', '/dre', '/cmv', '/fluxo-caixa',
       '/simulador', '/metas', '/estoque', '/cardapio', '/ai-assistant'
     ];
 


### PR DESCRIPTION
## Summary
- fix broken quick access links to `/fluxo-caixa`
- remove unused mobile sidebar in `ModernLayout`
- update audit helpers with new route

## Testing
- `npm run lint` *(fails: Unexpected any and require-imports errors)*

------
https://chatgpt.com/codex/tasks/task_e_68619f64c0fc8333a8f62989b492aa9e